### PR TITLE
Add 'My First Chat' to default chats

### DIFF
--- a/src/devtools/defaults.ts
+++ b/src/devtools/defaults.ts
@@ -2,6 +2,11 @@ import { Session } from './types'
 
 export const sessions: Session[] = [
     {
+        "id": "3e8d1bb9-1a7f-4e9a-9f4c-1d2b7a0f0c11",
+        "name": "My First Chat",
+        "messages": []
+    },
+    {
         "id": "1bc7094f-1248-4b51-8ac8-180a5a1470aa",
         "name": "Random Talk",
         "messages": [


### PR DESCRIPTION
Add 'My First Chat' to the default sessions list and place it at the front.

---
<a href="https://cursor.com/background-agent?bcId=bc-b15f3031-e287-496d-87c6-4c465df32073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b15f3031-e287-496d-87c6-4c465df32073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

