### PR TITLE
Add "My First Chat" to default chats

### DIFF
--- a/src/renderer/packages/initial_data.ts
+++ b/src/renderer/packages/initial_data.ts
@@ -1030,5 +1030,15 @@ mindmap
   threads: [],
 }
 
+// Minimal default chat that must appear at the very top of the sidebar
+export const myFirstChatSessionEN: Session = {
+  id: 'my-first-chat-default',
+  name: 'My First Chat',
+  type: 'chat',
+  messages: [].map(migrateMessage),
+}
+
 defaultSessionsForCN.unshift(imageCreatorSessionForCN, artifactSessionCN, mermaidSessionCN)
 defaultSessionsForEN.unshift(imageCreatorSessionForEN, artifactSessionEN, mermaidSessionEN)
+defaultSessionsForEN.unshift(myFirstChatSessionEN)
+defaultSessionsForCN.unshift(myFirstChatSessionEN)


### PR DESCRIPTION
### Description

Adds a new default chat session titled "My First Chat" to the application's initial data. This ensures "My First Chat" appears at the very top of the left navigation panel's default chat list for both English and Chinese locales. The new entry is a minimal `Session` object, providing only a title and no additional functionality.

### Additional Notes

This change is purely for initial UI rendering of the default chat list and does not introduce any new features or logic beyond displaying the new chat title.

### Screenshots

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

**Please check the box below to confirm:**

[ ] I have read and agree with the above statement.

---
<a href="https://cursor.com/background-agent?bcId=bc-37933720-bd8f-4bc9-afc7-e70604d0e383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37933720-bd8f-4bc9-afc7-e70604d0e383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

